### PR TITLE
Fixes for Issues & Updates for HTTPS connections

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
 			// Automatically stop program after launch.
 			"stopOnEntry": false,
 			// Command line arguments passed to the program.
-			"args": ["-t","10000","-R","spec","-u","tdd","--recursive","./obj/test"],
+			"args": ["-t","10000","-R","spec","-u","tdd", "--colors", "--recursive","./obj/test"],
 			// Workspace relative or absolute path to the working directory of the program being debugged. Default is the current workspace.
 			"cwd": "${workspaceRoot}",
 			//

--- a/src/clients/RestClient.ts
+++ b/src/clients/RestClient.ts
@@ -79,7 +79,7 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
         "connection.host", "0.0.0.0",
         "connection.port", 3000,
 
-        "options.request_max_size", 1024*1024,
+        "options.request_max_size", 1024 * 1024,
         "options.connect_timeout", 10000,
         "options.timeout", 10000,
         "options.retries", 3,
@@ -129,16 +129,16 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
     /**
      * The remote service uri which is calculated on open.
      */
-	protected _uri: string;
+    protected _uri: string;
 
     /**
      * Configures component by passing configuration parameters.
      * 
      * @param config    configuration parameters to be set.
      */
-	public configure(config: ConfigParams): void {
-		config = config.setDefaults(RestClient._defaultConfig);
-		this._connectionResolver.configure(config);
+    public configure(config: ConfigParams): void {
+        config = config.setDefaults(RestClient._defaultConfig);
+        this._connectionResolver.configure(config);
         this._options = this._options.override(config.getSection("options"));
 
         this._retries = config.getAsIntegerWithDefault("options.retries", this._retries);
@@ -146,18 +146,18 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
         this._timeout = config.getAsIntegerWithDefault("options.timeout", this._timeout);
 
         this._baseRoute = config.getAsStringWithDefault("base_route", this._baseRoute);
-	}
-        
+    }
+
     /**
 	 * Sets references to dependent components.
 	 * 
 	 * @param references 	references to locate the component dependencies. 
      */
-	public setReferences(references: IReferences): void {
-		this._logger.setReferences(references);
-		this._counters.setReferences(references);
-		this._connectionResolver.setReferences(references);
-	}
+    public setReferences(references: IReferences): void {
+        this._logger.setReferences(references);
+        this._counters.setReferences(references);
+        this._connectionResolver.setReferences(references);
+    }
 
     /**
      * Adds instrumentation to log calls and measure call time.
@@ -167,12 +167,12 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
      * @param name              a method name.
      * @returns Timing object to end the time measurement.
      */
-	protected instrument(correlationId: string, name: string): Timing {
-		this._logger.trace(correlationId, "Calling %s method", name);
+    protected instrument(correlationId: string, name: string): Timing {
+        this._logger.trace(correlationId, "Calling %s method", name);
         this._counters.incrementOne(name + '.call_count');
-		return this._counters.beginTiming(name + ".call_time");
+        return this._counters.beginTiming(name + ".call_time");
     }
-    
+
     /**
      * Adds instrumentation to error handling.
      * 
@@ -186,7 +186,7 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
         result: any = null, callback: (err: any, result: any) => void = null): void {
         if (err != null) {
             this._logger.error(correlationId, err, "Failed to call %s method", name);
-            this._counters.incrementOne(name + '.call_errors');    
+            this._counters.incrementOne(name + '.call_errors');
         }
 
         if (callback) callback(err, result);
@@ -197,23 +197,23 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
 	 * 
 	 * @returns true if the component has been opened and false otherwise.
      */
-	public isOpen(): boolean {
-		return this._client != null;
-	}
-    
+    public isOpen(): boolean {
+        return this._client != null;
+    }
+
     /**
 	 * Opens the component.
 	 * 
 	 * @param correlationId 	(optional) transaction id to trace execution through call chain.
      * @param callback 			callback function that receives error or null no errors occured.
      */
-	public open(correlationId: string, callback?: (err: any) => void): void {
+    public open(correlationId: string, callback?: (err: any) => void): void {
         if (this.isOpen()) {
             if (callback) callback(null);
             return;
         }
-    	
-		this._connectionResolver.resolve(correlationId, (err, connection) => {
+
+        this._connectionResolver.resolve(correlationId, (err, connection) => {
             if (err) {
                 if (callback) callback(err);
                 return;
@@ -222,8 +222,8 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
             try {
                 this._uri = connection.getUri();
                 let restify = require('restify-clients');
-                this._client = restify.createJsonClient({ 
-                    url: this._uri, 
+                this._client = restify.createJsonClient({
+                    url: this._uri,
                     connectTimeout: this._connectTimeout,
                     requestTimeout: this._timeout,
                     headers: this._headers,
@@ -232,18 +232,19 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
                         maxTimeout: Infinity,
                         retries: this._retries
                     },
-                    version: '*' 
+                    version: '*'
                 });
-                
+
+                this._logger.debug(correlationId, "Connected via REST to %s", this._uri);
                 if (callback) callback(null);
             } catch (err) {
-                this._client = null;            
+                this._client = null;
                 let ex = new ConnectionException(correlationId, "CANNOT_CONNECT", "Connection to REST service failed")
                     .wrap(err).withDetails("url", this._uri);
                 if (callback) callback(ex);
             }
         });
-		
+
     }
 
     /**
@@ -297,7 +298,7 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
     protected addFilterParams(params: any, filter: any): void {
         params = params || {};
 
-        if (filter) {       
+        if (filter) {
             for (let prop in filter) {
                 if (filter.hasOwnProperty(prop))
                     params[prop] = filter[prop];
@@ -355,11 +356,11 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
      * @param data              (optional) body object.
      * @param callback          (optional) callback function that receives result object or error.
      */
-    protected call(method: string, route: string, correlationId?: string, params: any = {}, data?: any, 
+    protected call(method: string, route: string, correlationId?: string, params: any = {}, data?: any,
         callback?: (err: any, result: any) => void): void {
-        
+
         method = method.toLowerCase();
-                
+
         if (_.isFunction(data)) {
             callback = data;
             data = {};
@@ -370,9 +371,9 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
         params = this.addCorrelationId(params, correlationId)
         if (!_.isEmpty(params))
             route += '?' + querystring.stringify(params);
-                    
+
         let self = this;
-        let action = null;    
+        let action = null;
         if (callback) {
             action = (err, req, res, data) => {
                 // Handling 204 codes
@@ -384,11 +385,11 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
                     // Restore application exception
                     if (data != null)
                         err = ApplicationExceptionFactory.create(data).withCause(err);
-                    callback.call(self, err, null);  
+                    callback.call(self, err, null);
                 }
             };
         }
-        
+
         if (method == 'get') this._client.get(route, action);
         else if (method == 'head') this._client.head(route, action);
         else if (method == 'post') this._client.post(route, data, action);
@@ -401,6 +402,6 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
             if (callback) callback(error, null)
             else throw error;
         }
-    }    
+    }
 
 }

--- a/src/clients/RestClient.ts
+++ b/src/clients/RestClient.ts
@@ -168,9 +168,10 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
      * @returns Timing object to end the time measurement.
      */
     protected instrument(correlationId: string, name: string): Timing {
-        this._logger.trace(correlationId, "Calling %s method", name);
-        this._counters.incrementOne(name + '.call_count');
-        return this._counters.beginTiming(name + ".call_time");
+        const typeName = this.constructor.name || "unknown-target";
+        this._logger.trace(correlationId, "Calling %s method of %s", name, typeName);
+        this._counters.incrementOne(typeName + "." + name + '.call_count');
+        return this._counters.beginTiming(typeName + "." + name + ".call_time");
     }
 
     /**
@@ -185,8 +186,9 @@ export abstract class RestClient implements IOpenable, IConfigurable, IReference
     protected instrumentError(correlationId: string, name: string, err: any,
         result: any = null, callback: (err: any, result: any) => void = null): void {
         if (err != null) {
-            this._logger.error(correlationId, err, "Failed to call %s method", name);
-            this._counters.incrementOne(name + '.call_errors');
+            const typeName = this.constructor.name || "unknown-target";
+            this._logger.error(correlationId, err, "Failed to call %s method of %s", name, typeName);
+            this._counters.incrementOne(typeName + "." + name + '.call_errors');
         }
 
         if (callback) callback(err, result);

--- a/src/connect/HttpConnectionResolver.ts
+++ b/src/connect/HttpConnectionResolver.ts
@@ -112,12 +112,17 @@ export class HttpConnectionResolver implements IReferenceable, IConfigurable {
                 return new ConfigException(
                     correlationId, "NO_CREDENTIAL", "SSL certificates are not configured for HTTPS protocol");
             } else {
-                if (credential.getAsNullableString('ssl_key_file') == null) {
-                    return new ConfigException(
-                        correlationId, "NO_SSL_KEY_FILE", "SSL key file is not configured in credentials");
-                } else if (credential.getAsNullableString('ssl_crt_file') == null) {
-                    return new ConfigException(
-                        correlationId, "NO_SSL_CRT_FILE", "SSL crt file is not configured in credentials");
+                // Sometimes when we use https we are on an internal network and do not want to have to deal with security.
+                // When we need a https connection and we don't want to pass credentials, flag is 'credential.internal_network',
+                // this flag just has to be present and non null for this functionality to work.
+                if (credential.GetAsNullableString("internal_network") == null) {
+                    if (credential.getAsNullableString('ssl_key_file') == null) {
+                        return new ConfigException(
+                            correlationId, "NO_SSL_KEY_FILE", "SSL key file is not configured in credentials");
+                    } else if (credential.getAsNullableString('ssl_crt_file') == null) {
+                        return new ConfigException(
+                            correlationId, "NO_SSL_CRT_FILE", "SSL crt file is not configured in credentials");
+                    }
                 }
             }
         }
@@ -140,7 +145,7 @@ export class HttpConnectionResolver implements IReferenceable, IConfigurable {
                 uri += ':' + port;
             connection.setUri(uri);
         } else {
-            let address = url.parse(uri);            
+            let address = url.parse(uri);
             let protocol = ("" + address.protocol).replace(':', '');
 
             connection.setProtocol(protocol);
@@ -158,7 +163,7 @@ export class HttpConnectionResolver implements IReferenceable, IConfigurable {
      */
     public resolve(correlationId: string,
         callback: (err: any, connection: ConnectionParams, credential: CredentialParams) => void): void {
-        
+
         this._connectionResolver.resolve(correlationId, (err: any, connection: ConnectionParams) => {
             if (err) {
                 callback(err, null, null);
@@ -171,7 +176,7 @@ export class HttpConnectionResolver implements IReferenceable, IConfigurable {
 
                 if (err == null && connection != null)
                     this.updateConnection(connection);
-        
+
                 callback(err, connection, credential);
             });
         });
@@ -192,23 +197,23 @@ export class HttpConnectionResolver implements IReferenceable, IConfigurable {
                 callback(err, null, null);
                 return;
             }
-            
+
             this._credentialResolver.lookup(correlationId, (err, credential) => {
                 connections = connections || [];
-            
+
                 for (let connection of connections) {
                     if (err == null)
                         err = this.validateConnection(correlationId, connection, credential);
-    
+
                     if (err == null && connection != null)
                         this.updateConnection(connection);
                 }
-        
-                callback(err, connections, credential);    
+
+                callback(err, connections, credential);
             });
         });
     }
-    
+
     /**
      * Registers the given connection in all referenced discovery services.
      * This method can be used for dynamic service discovery.
@@ -229,7 +234,7 @@ export class HttpConnectionResolver implements IReferenceable, IConfigurable {
                 if (err == null)
                     err = this.validateConnection(correlationId, connection, credential);
 
-                if (err == null) 
+                if (err == null)
                     this._connectionResolver.register(correlationId, connection, callback);
                 else callback(err);
             });

--- a/src/connect/HttpConnectionResolver.ts
+++ b/src/connect/HttpConnectionResolver.ts
@@ -115,7 +115,7 @@ export class HttpConnectionResolver implements IReferenceable, IConfigurable {
                 // Sometimes when we use https we are on an internal network and do not want to have to deal with security.
                 // When we need a https connection and we don't want to pass credentials, flag is 'credential.internal_network',
                 // this flag just has to be present and non null for this functionality to work.
-                if (credential.GetAsNullableString("internal_network") == null) {
+                if (credential.getAsNullableString("internal_network") == null) {
                     if (credential.getAsNullableString('ssl_key_file') == null) {
                         return new ConfigException(
                             correlationId, "NO_SSL_KEY_FILE", "SSL key file is not configured in credentials");
@@ -130,7 +130,7 @@ export class HttpConnectionResolver implements IReferenceable, IConfigurable {
         return null;
     }
 
-    private updateConnection(connection: ConnectionParams): void {
+    private updateConnection(connection: ConnectionParams, credential: CredentialParams): void {
         if (connection == null) return;
 
         let uri = connection.getUri();
@@ -152,6 +152,13 @@ export class HttpConnectionResolver implements IReferenceable, IConfigurable {
             connection.setHost(address.hostname);
             connection.setPort(address.port);
         }
+
+        if (connection.getProtocol() == "https") {
+            connection.addSection("credential",
+                credential.getAsNullableString("internal_network") == null ? credential : new CredentialParams());
+        } else {
+            connection.addSection("credential", new CredentialParams());
+        }
     }
 
     /**
@@ -171,12 +178,12 @@ export class HttpConnectionResolver implements IReferenceable, IConfigurable {
             }
 
             this._credentialResolver.lookup(correlationId, (err: any, credential: CredentialParams) => {
-                if (err == null)
+                if (err == null) {
                     err = this.validateConnection(correlationId, connection, credential);
-
-                if (err == null && connection != null)
-                    this.updateConnection(connection);
-
+                }
+                if (err == null && connection != null) {
+                    this.updateConnection(connection, credential);
+                }
                 callback(err, connection, credential);
             });
         });
@@ -202,11 +209,12 @@ export class HttpConnectionResolver implements IReferenceable, IConfigurable {
                 connections = connections || [];
 
                 for (let connection of connections) {
-                    if (err == null)
+                    if (err == null) {
                         err = this.validateConnection(correlationId, connection, credential);
-
-                    if (err == null && connection != null)
-                        this.updateConnection(connection);
+                    }
+                    if (err == null && connection != null) {
+                        this.updateConnection(connection, credential);
+                    }
                 }
 
                 callback(err, connections, credential);

--- a/src/services/CommandableHttpService.ts
+++ b/src/services/CommandableHttpService.ts
@@ -92,7 +92,7 @@ export abstract class CommandableHttpService extends RestService {
 
             this.registerRoute('post', route, null, (req, res) => {
                 let params = req.body || {};
-                let correlationId = req.params.correlation_id;
+                let correlationId = req.query.correlation_id;
                 let args = Parameters.fromValue(params);
                 let timing = this.instrument(correlationId, this._baseRoute + '.' + command.getName());
 

--- a/test/connect/HttpConnectionResolver.test.ts
+++ b/test/connect/HttpConnectionResolver.test.ts
@@ -1,10 +1,10 @@
 let assert = require('chai').assert;
 
-import {  ConfigParams } from 'pip-services3-commons-node';
+import { ConfigParams, ConfigException } from 'pip-services3-commons-node';
 
 import { HttpConnectionResolver } from '../../src/connect/HttpConnectionResolver';
 
-suite('HttpConnectionResolver', ()=> {
+suite('HttpConnectionResolver', () => {
 
     test('Resolve URI', (done) => {
         let resolver = new HttpConnectionResolver();
@@ -35,5 +35,126 @@ suite('HttpConnectionResolver', ()=> {
             done();
         });
     });
-    
+
+    test('TestHttpsWithCredentialsConnectionParams', (done) => {
+
+        let resolver = new HttpConnectionResolver();
+        resolver.configure(ConfigParams.fromTuples(
+            "connection.host", "somewhere.com",
+            "connection.port", 123,
+            "connection.protocol", "https",
+            "credential.ssl_key_file", "ssl_key_file",
+            "credential.ssl_crt_file", "ssl_crt_file"
+        ));
+
+        resolver.resolve(null, (err, connection) => {
+            assert.equal("https", connection.getProtocol());
+            assert.equal("somewhere.com", connection.getHost());
+            assert.equal(123, connection.getPort());
+            assert.equal("https://somewhere.com:123", connection.getUri());
+            assert.equal("ssl_key_file", connection.get("credential.ssl_key_file"));
+            assert.equal("ssl_crt_file", connection.get("credential.ssl_crt_file"));
+
+            done();
+        });
+    });
+
+    test('TestHttpsWithNoCredentialsConnectionParams', (done) => {
+
+        let resolver = new HttpConnectionResolver();
+        resolver.configure(ConfigParams.fromTuples(
+            "connection.host", "somewhere.com",
+            "connection.port", 123,
+            "connection.protocol", "https",
+            "credential.internal_network", "internal_network"
+        ));
+
+        resolver.resolve(null, (err, connection) => {
+            assert.equal("https", connection.getProtocol());
+            assert.equal("somewhere.com", connection.getHost());
+            assert.equal(123, connection.getPort());
+            assert.equal("https://somewhere.com:123", connection.getUri());
+            assert.isNull(connection.get("credential.internal_network"));
+
+            done();
+        });
+    });
+
+    test('TestHttpsWithMissingCredentialsConnectionParams', (done) => {
+
+        // section missing
+        let resolver = new HttpConnectionResolver();
+        resolver.configure(ConfigParams.fromTuples(
+            "connection.host", "somewhere.com",
+            "connection.port", 123,
+            "connection.protocol", "https"
+        ));
+
+        resolver.resolve(null, (err, connection) => {
+            console.log("Test - section missing");
+            assert.isNotNull(err);
+            assert.equal("NO_CREDENTIAL", err.code);
+            assert.equal("NO_CREDENTIAL", err.name);
+            assert.equal("SSL certificates are not configured for HTTPS protocol", err.message);
+            assert.equal("Misconfiguration", err.category);
+        });
+
+        // ssl_crt_file missing
+        resolver = new HttpConnectionResolver();
+        resolver.configure(ConfigParams.fromTuples(
+            "connection.host", "somewhere.com",
+            "connection.port", 123,
+            "connection.protocol", "https",
+            "credential.ssl_key_file", "ssl_key_file"
+        ));
+
+        resolver.resolve(null, (err, connection) => {
+            console.log("Test - ssl_crt_file missing");
+            assert.isNotNull(err);
+            assert.equal("NO_SSL_CRT_FILE", err.code);
+            assert.equal("NO_SSL_CRT_FILE", err.name);
+            assert.equal("SSL crt file is not configured in credentials", err.message);
+            assert.equal("Misconfiguration", err.category);
+        });
+
+        // ssl_key_file missing
+        resolver = new HttpConnectionResolver();
+        resolver.configure(ConfigParams.fromTuples(
+            "connection.host", "somewhere.com",
+            "connection.port", 123,
+            "connection.protocol", "https",
+            "credential.ssl_crt_file", "ssl_crt_file"
+        ));
+
+        resolver.resolve(null, (err, connection) => {
+            console.log("Test - ssl_key_file missing");
+            assert.isNotNull(err);
+            assert.equal("NO_SSL_KEY_FILE", err.code);
+            assert.equal("NO_SSL_KEY_FILE", err.name);
+            assert.equal("SSL key file is not configured in credentials", err.message);
+            assert.equal("Misconfiguration", err.category);
+        });
+
+        // ssl_key_file,  ssl_crt_file present
+        resolver = new HttpConnectionResolver();
+        resolver.configure(ConfigParams.fromTuples(
+            "connection.host", "somewhere.com",
+            "connection.port", 123,
+            "connection.protocol", "https",
+            "credential.ssl_key_file", "ssl_key_file",
+            "credential.ssl_crt_file", "ssl_crt_file"
+        ));
+
+        resolver.resolve(null, (err, connection) => {
+            console.log("Test - ssl_key_file,  ssl_crt_file present");
+            assert.equal("https", connection.getProtocol());
+            assert.equal("somewhere.com", connection.getHost());
+            assert.equal(123, connection.getPort());
+            assert.equal("https://somewhere.com:123", connection.getUri());
+            assert.equal("ssl_key_file", connection.get("credential.ssl_key_file"));
+            assert.equal("ssl_crt_file", connection.get("credential.ssl_crt_file"));
+
+            done();
+        });
+    });
 });


### PR DESCRIPTION
**Overview**

Please see the issue [here](https://github.com/pip-services3-node/pip-services3-rpc-node/issues/2)
Adding functionality that exists in the dotnet version of the project from the PR here - https://github.com/pip-services3-dotnet/pip-services3-rpc-dotnet/pull/2

**HTTPS connection resolution with no credentials implemented for internal networks**

The issue we have is that elastic search in AWS, which requires HTTPS, but no SSL credentials (for the way it's being implemented)

HTTPS connections are forced to have SSL credentials in the RPC project.  
I've added a flag that will skip credentials when HTTPS is used.  
The flag is 'credential.internal_network', this flag just has to be present and non null for this functionality to work.

Unit tests have also been added for this change.

**Mocha Launch Task Updates**

I've added the color switch to the mocha task.

**Functionality from dotnet package**

I've added the functionality that exists in the dotnet version of the package, the code is below.

```ts
if (connection.getProtocol() == "https") {
    connection.addSection("credential",
        credential.getAsNullableString("internal_network") == null ? credential : new CredentialParams());
} else {
    connection.addSection("credential", new CredentialParams());
}
```

_WARNING_ - Disregard, new info added.
This code will break exsting implementations that use https with no credentials.  
I can remove it and submit another PR if this functionality is unwanted at this time.

The exsiting code in the `HttpConnectionResolver` method `validateConnection` will throw if https is used without credentials

```ts
 // Check HTTPS credentials
        if (protocol == "https") {
            // Check for credential
            if (credential == null) {
                return new ConfigException(
                    correlationId, "NO_CREDENTIAL", "SSL certificates are not configured for HTTPS protocol");
            } else {
```

**NOTE**  
The existing setup in the dotnet version of the project uses the properties names  
    - `ssl_password`  
    - `ssl_pfx_file`  
while the existing property names in the node version are  
    - `ssl_key_file`  
    - `ssl_crt_file`  

I have kept this as is, just letting you know about the differences.
